### PR TITLE
Add missing ponder lang

### DIFF
--- a/overrides/kubejs/assets/create/lang/en_us.json
+++ b/overrides/kubejs/assets/create/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "create.ponder.tag.base": "Other Components",
+  "create.ponder.tag.base.description": "Other things that don't fit in the previous catagories"
+}


### PR DESCRIPTION
Some lang was missing for one of the (empty) ponder options
i fixed it :+1:

Before:
<img width="521" height="100" alt="image" src="https://github.com/user-attachments/assets/4bf6d202-a7ca-4160-8e09-951160b488b3" />

After:
<img width="424" height="117" alt="image" src="https://github.com/user-attachments/assets/b47f7647-bf4f-4789-a476-3121fb4d5db0" />
<img width="2050" height="1170" alt="image" src="https://github.com/user-attachments/assets/93d5b639-665d-47f7-a3bd-430188743a24" />
