### PR TITLE
Reversible recipe for storage container -> item vault

### DIFF
--- a/overrides/kubejs/server_scripts/Misc.js
+++ b/overrides/kubejs/server_scripts/Misc.js
@@ -1,0 +1,8 @@
+ServerEvents.recipes(event => {
+    event.shaped('4x create:item_vault', [
+        'CC',
+        'CC'
+    ], {
+        C: 'dndecor:storage_container'
+    }).id('creatorio:item_vault_from_storage_container')
+})


### PR DESCRIPTION
Storage containers (different look for vaults) can't be crafted back into item vaults, unlike shipping containers and item silos. Original recipe below
<img width="437" height="203" alt="image" src="https://github.com/user-attachments/assets/8bdea3a1-cbd2-4fff-8e91-bd5fb34df1ca" />
