### PR TITLE
ConsoleFilter config

### DIFF
--- a/overrides/config/consolefilter-common.toml
+++ b/overrides/config/consolefilter-common.toml
@@ -1,0 +1,11 @@
+[general]
+	#Any console messages containing any of these strings will be hidden.
+	basicFilters = [
+		"Cannot invoke \"xaero.map.WorldMapSession.getMapProcessor()\" because \"session\" is null",
+		"Couldn't load vanilla shader from",
+		"Failed to get Road Sign Block Entity during generation."
+	]
+	#Any console messages containing any of these regular expressions will be hidden. Uses Java regex syntax. Backslashes must be doubled, i.e. use \\s instead of \s to match whitespace.
+	regexFilters = []
+	#Any console messages from loggers with a name containing any of these strings will be hidden.
+	loggerFilters = []


### PR DESCRIPTION
Adds three logs to filter out:
- FTB Chunks Xaero's log spam
- Veil vanilla shader spam for Malum/Lodestone
- Suppl DH road sign

Not including manifest change here, I'll trust you to do that. Link to mod: https://www.curseforge.com/minecraft/mc-mods/console-filter