### PR TITLE
Add Reese's Sodium Options to server pack blacklist

### DIFF
--- a/server-mods-config.json
+++ b/server-mods-config.json
@@ -12,7 +12,8 @@
     {"name": "Too Many Recipe Viewwers", "id": 1194921 },
     {"name": "Prism", "id": 638111 },
     {"name": "Iceberg", "id": 520110 },
-    {"name": "Better Clouds", "id": 1285973 }
+    {"name": "Better Clouds", "id": 1285973 },
+    {"name": "Reese's Sodium Options", "id": 511319 }
   ],
   "manual_download": [
   ],


### PR DESCRIPTION
Reese's is a client side mod, and depends on Sodium, causing potential server crashes