### PR TITLE
Remove the Fluid Hatch from Create: Dragons Plus

### DIFF
--- a/overrides/kubejs/server_scripts/RecipeRemovals.js
+++ b/overrides/kubejs/server_scripts/RecipeRemovals.js
@@ -320,6 +320,7 @@ yeet('create_new_age:reactor_rod')
 yeet('create_new_age:reactor_glass')
 yeet('create_new_age:reactor_fuel_acceptor')
 yeet('create_new_age:reactor_heat_vent')
+yeet('create_dragons_plus:fluid_hatch')
 
 ServerEvents.recipes(event => {
   


### PR DESCRIPTION
It has the ability to do input and output

The one from Dreams n' Desire only do input