### PR TITLE
ungroup ftb ultimine stones

### DIFF
--- a/overrides/config/ftbultimine-server.snbt
+++ b/overrides/config/ftbultimine-server.snbt
@@ -72,7 +72,6 @@
 		# These tags will be considered the same block when checking for blocks to Ultimine in shapeless mining mode
 		# Default: ["minecraft:base_stone_overworld", "c:ores/*", "forge:ores/*"]
 		merge_tags: [
-			"minecraft:base_stone_overworld"
 			"c:ores/*"
 			"forge:ores/*"
 		]


### PR DESCRIPTION
if you mine granite next to andesite it will only mine the granite now instead of both etc